### PR TITLE
fix(build): resolve compilation errors

### DIFF
--- a/app/src/main/java/com/gamecamp/ui/screens/DriverScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/DriverScreen.kt
@@ -1,6 +1,7 @@
 package com.gamecamp.ui.screens
 
 import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/com/gamecamp/ui/screens/EnhancedDriverScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/EnhancedDriverScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -94,9 +96,12 @@ fun EnhancedDriverScreen(
         }
 
         // 终端对话框
-        if (showTerminalDialog) {
+        AnimatedVisibility(
+            visible = showTerminalDialog,
+            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
+            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+        ) {
             TerminalDialog(
-                isVisible = showTerminalDialog,
                 logs = terminalLogs,
                 isCompleted = terminalCompleted,
                 onDismiss = { viewModel.closeTerminalDialog() }

--- a/app/src/main/java/com/gamecamp/ui/screens/GameAssistantScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/GameAssistantScreen.kt
@@ -3,6 +3,8 @@ package com.gamecamp.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -70,22 +72,30 @@ fun GameAssistantScreen(
         }
 
         // 辅助功能设置对话框
-        AssistantSettingsDialog(
-            isVisible = showAssistantDialog,
-            currentSettings = assistantSettings,
-            onConfirm = { settings ->
-                showAssistantDialog = false
-                viewModel.launchAssistant(settings)
-            },
-            onDismiss = {
-                showAssistantDialog = false
-            }
-        )
+        AnimatedVisibility(
+            visible = showAssistantDialog,
+            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
+            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+        ) {
+            AssistantSettingsDialog(
+                currentSettings = assistantSettings,
+                onConfirm = { settings ->
+                    showAssistantDialog = false
+                    viewModel.launchAssistant(settings)
+                },
+                onDismiss = {
+                    showAssistantDialog = false
+                }
+            )
+        }
 
         // 终端对话框
-        if (showTerminalDialog) {
+        AnimatedVisibility(
+            visible = showTerminalDialog,
+            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
+            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+        ) {
             TerminalDialog(
-                isVisible = showTerminalDialog,
                 logs = terminalLogs,
                 isCompleted = terminalCompleted,
                 onDismiss = { viewModel.closeTerminalDialog() }


### PR DESCRIPTION
This commit fixes several compilation errors that were introduced in the previous commit while adding UI animations.

- Adds the explicit `tween` import to `DriverScreen.kt` to resolve the 'Unresolved reference' error.
- Updates dialog call sites in `EnhancedDriverScreen.kt` and `GameAssistantScreen.kt` to correctly use `AnimatedVisibility`. The previous refactoring of the dialogs was incomplete and missed these usage locations.