### PR TITLE
fix(build): Pass modifier to InfoCard to resolve build error

### DIFF
--- a/app/src/main/java/com/gamecamp/ui/components/InfoCard.kt
+++ b/app/src/main/java/com/gamecamp/ui/components/InfoCard.kt
@@ -24,10 +24,11 @@ import com.gamecamp.ui.theme.WarmOrange
 fun InfoCard(
     title: String,
     icon: ImageVector,
+    modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp)),
         colors = CardDefaults.cardColors(


### PR DESCRIPTION
This commit fixes the final compilation error that was causing the build to fail. The root cause was that the base `InfoCard` component did not accept a `modifier` parameter, which prevented animation modifiers from being applied to it.

- The `InfoCard` composable in `InfoCard.kt` has been updated to accept and apply a `Modifier`.
- This resolves the `No parameter with name 'modifier' found` and the related `@Composable invocations` errors in `DriverScreen.kt`.