### PR TITLE
feat(ui): improve animation fluidity with stagger and spring

### DIFF
--- a/app/src/main/java/com/gamecamp/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/DashboardScreen.kt
@@ -189,170 +189,171 @@ fun DashboardScreen(
             Spacer(modifier = Modifier.height(16.dp))
         }
 
-        var contentVisible by remember { mutableStateOf(false) }
-        LaunchedEffect(Unit) {
-            contentVisible = true
+        val dashboardItems = remember {
+            listOf<@Composable () -> Unit>(
+                {
+                    InfoCard(title = "内核信息", icon = Icons.Default.Memory) {
+                        Crossfade(targetState = isLoading, label = "KernelInfoCrossfade") { loading ->
+                            Column {
+                                if (loading) {
+                                    repeat(3) {
+                                        LoadingInfoRow()
+                                        if (it < 2) Spacer(modifier = Modifier.height(12.dp))
+                                    }
+                                } else {
+                                    kernelInfo.entries.forEachIndexed { index, (key, value) ->
+                                        SystemInfoRow(
+                                            label = key,
+                                            value = value,
+                                            isMonospace = key == "编译信息"
+                                        )
+                                        if (index < kernelInfo.size - 1) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    InfoCard(title = "SELinux状态", icon = Icons.Default.Security) {
+                        Crossfade(targetState = isLoading, label = "SelinuxCrossfade") { loading ->
+                            Column {
+                                if (loading) {
+                                    repeat(3) {
+                                        LoadingInfoRow()
+                                        if (it < 2) Spacer(modifier = Modifier.height(12.dp))
+                                    }
+                                } else {
+                                    selinuxInfo.entries.forEachIndexed { index, (key, value) ->
+                                        val targetColor = when {
+                                            key == "SELinux状态" && value.contains("Enforcing") -> MaterialTheme.colorScheme.primary
+                                            key == "SELinux状态" && value.contains("Permissive") -> MaterialTheme.colorScheme.tertiary
+                                            key == "SELinux状态" && value.contains("Disabled") -> MaterialTheme.colorScheme.error
+                                            key == "SELinux状态" && value.contains("需要Root权限") -> MaterialTheme.colorScheme.secondary
+                                            else -> MaterialTheme.colorScheme.onSurface
+                                        }
+                                        val valueColor by animateColorAsState(
+                                            targetValue = targetColor,
+                                            label = "SelinuxColorAnimation"
+                                        )
+
+                                        SystemInfoRow(
+                                            label = key,
+                                            value = value,
+                                            valueColor = valueColor
+                                        )
+                                        if (index < selinuxInfo.size - 1) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+
+                                    if (selinuxInfo["SELinux状态"]?.contains("需要Root权限") == true) {
+                                        Spacer(modifier = Modifier.height(12.dp))
+                                        Button(
+                                            onClick = { /* Root权限获取指南 */ },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = WarmNeumorphismColors.WarmOrange.copy(alpha = 0.8f),
+                                                contentColor = Color.White
+                                            ),
+                                            modifier = Modifier.fillMaxWidth()
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Security,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                            Spacer(modifier = Modifier.width(8.dp))
+                                            Text(
+                                                text = "了解Root权限获取",
+                                                style = MaterialTheme.typography.labelMedium
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    InfoCard(title = "设备信息", icon = Icons.Default.PhoneAndroid) {
+                        Crossfade(targetState = isLoading, label = "DeviceInfoCrossfade") { loading ->
+                            Column {
+                                if (loading) {
+                                    repeat(4) {
+                                        LoadingInfoRow()
+                                        if (it < 3) Spacer(modifier = Modifier.height(12.dp))
+                                    }
+                                } else {
+                                    deviceInfo.entries.forEachIndexed { index, (key, value) ->
+                                        SystemInfoRow(
+                                            label = key,
+                                            value = value
+                                        )
+                                        if (index < deviceInfo.size - 1) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    InfoCard(title = "设备指纹", icon = Icons.Default.Fingerprint) {
+                        Crossfade(targetState = isLoading, label = "FingerprintCrossfade") { loading ->
+                            Column {
+                                if (loading) {
+                                    repeat(4) {
+                                        LoadingInfoRow()
+                                        if (it < 3) Spacer(modifier = Modifier.height(12.dp))
+                                    }
+                                } else {
+                                    fingerprintInfo.entries.forEachIndexed { index, (key, value) ->
+                                        SystemInfoRow(
+                                            label = key,
+                                            value = value,
+                                            isMonospace = key == "设备指纹"
+                                        )
+                                        if (index < fingerprintInfo.size - 1) {
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    TelegramChannelButton()
+                }
+            )
         }
 
-        AnimatedVisibility(
-            visible = contentVisible,
-            enter = fadeIn(animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)) +
-                    slideInVertically(
-                        animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
-                        initialOffsetY = { it / 2 }
-                    ),
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                // 内核信息卡片
-                InfoCard(
-                    title = "内核信息",
-                    icon = Icons.Default.Memory
-                ) {
-                    Crossfade(targetState = isLoading, label = "KernelInfoCrossfade") { loading ->
-                        Column {
-                            if (loading) {
-                                repeat(3) {
-                                    LoadingInfoRow()
-                                    if (it < 2) Spacer(modifier = Modifier.height(12.dp))
-                                }
-                            } else {
-                                kernelInfo.entries.forEachIndexed { index, (key, value) ->
-                                    SystemInfoRow(
-                                        label = key,
-                                        value = value,
-                                        isMonospace = key == "编译信息"
-                                    )
-                                    if (index < kernelInfo.size - 1) {
-                                        Spacer(modifier = Modifier.height(8.dp))
-                                    }
-                                }
-                            }
-                        }
-                    }
+        dashboardItems.forEachIndexed { index, item ->
+            val state = remember {
+                MutableTransitionState(false).apply {
+                    targetState = false
                 }
-                
-                // SELinux状态卡片
-                InfoCard(
-                    title = "SELinux状态",
-                    icon = Icons.Default.Security
-                ) {
-                    Crossfade(targetState = isLoading, label = "SelinuxCrossfade") { loading ->
-                        Column {
-                            if (loading) {
-                                repeat(3) {
-                                    LoadingInfoRow()
-                                    if (it < 2) Spacer(modifier = Modifier.height(12.dp))
-                                }
-                            } else {
-                                selinuxInfo.entries.forEachIndexed { index, (key, value) ->
-                                    val targetColor = when {
-                                        key == "SELinux状态" && value.contains("Enforcing") -> MaterialTheme.colorScheme.primary
-                                        key == "SELinux状态" && value.contains("Permissive") -> MaterialTheme.colorScheme.tertiary
-                                        key == "SELinux状态" && value.contains("Disabled") -> MaterialTheme.colorScheme.error
-                                        key == "SELinux状态" && value.contains("需要Root权限") -> MaterialTheme.colorScheme.secondary
-                                        else -> MaterialTheme.colorScheme.onSurface
-                                    }
-                                    val valueColor by animateColorAsState(
-                                        targetValue = targetColor,
-                                        label = "SelinuxColorAnimation"
-                                    )
+            }
+            LaunchedEffect(Unit) {
+                delay(index * 80L)
+                state.targetState = true
+            }
 
-                                    SystemInfoRow(
-                                        label = key,
-                                        value = value,
-                                        valueColor = valueColor
-                                    )
-                                    if (index < selinuxInfo.size - 1) {
-                                        Spacer(modifier = Modifier.height(8.dp))
-                                    }
-                                }
-
-                                // 如果需要Root权限，显示获取按钮
-                                if (selinuxInfo["SELinux状态"]?.contains("需要Root权限") == true) {
-                                    Spacer(modifier = Modifier.height(12.dp))
-                                    Button(
-                                        onClick = { /* Root权限获取指南 */ },
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = WarmNeumorphismColors.WarmOrange.copy(alpha = 0.8f),
-                                            contentColor = Color.White
-                                        ),
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Security,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(16.dp)
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        Text(
-                                            text = "了解Root权限获取",
-                                            style = MaterialTheme.typography.labelMedium
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
+            AnimatedVisibility(
+                visibleState = state,
+                enter = fadeIn(animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessLow)) +
+                        slideInVertically(
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
+                            initialOffsetY = { it / 2 }
+                        )
+            ) {
+                Column {
+                    item()
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
-
-                // 设备信息卡片
-                InfoCard(
-                    title = "设备信息",
-                    icon = Icons.Default.PhoneAndroid
-                ) {
-                    Crossfade(targetState = isLoading, label = "DeviceInfoCrossfade") { loading ->
-                        Column {
-                            if (loading) {
-                                repeat(4) {
-                                    LoadingInfoRow()
-                                    if (it < 3) Spacer(modifier = Modifier.height(12.dp))
-                                }
-                            } else {
-                                deviceInfo.entries.forEachIndexed { index, (key, value) ->
-                                    SystemInfoRow(
-                                        label = key,
-                                        value = value
-                                    )
-                                    if (index < deviceInfo.size - 1) {
-                                        Spacer(modifier = Modifier.height(8.dp))
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // 设备指纹卡片
-                InfoCard(
-                    title = "设备指纹",
-                    icon = Icons.Default.Fingerprint
-                ) {
-                    Crossfade(targetState = isLoading, label = "FingerprintCrossfade") { loading ->
-                        Column {
-                            if (loading) {
-                                repeat(4) {
-                                    LoadingInfoRow()
-                                    if (it < 3) Spacer(modifier = Modifier.height(12.dp))
-                                }
-                            } else {
-                                fingerprintInfo.entries.forEachIndexed { index, (key, value) ->
-                                    SystemInfoRow(
-                                        label = key,
-                                        value = value,
-                                        isMonospace = key == "设备指纹"
-                                    )
-                                    if (index < fingerprintInfo.size - 1) {
-                                        Spacer(modifier = Modifier.height(8.dp))
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // TG频道引流按钮
-                TelegramChannelButton()
             }
         }
     }

--- a/app/src/main/java/com/gamecamp/ui/screens/DriverScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/DriverScreen.kt
@@ -1,7 +1,7 @@
 package com.gamecamp.ui.screens
 
 import androidx.compose.animation.*
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -92,8 +92,8 @@ fun DriverScreen(
         // 确认对话框
         AnimatedVisibility(
             visible = uiState.showConfirmDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             DriverResetConfirmDialog(
                 driverName = uiState.selectedDriver,
@@ -105,8 +105,8 @@ fun DriverScreen(
         // 辅助功能设置对话框
         AnimatedVisibility(
             visible = showAssistantDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             AssistantSettingsDialog(
                 currentSettings = assistantSettings,
@@ -123,8 +123,8 @@ fun DriverScreen(
         // 终端对话框
         AnimatedVisibility(
             visible = showTerminalDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             TerminalDialog(
                 logs = terminalLogs,

--- a/app/src/main/java/com/gamecamp/ui/screens/EnhancedDriverScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/EnhancedDriverScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.animation.*
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.*
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -98,8 +98,8 @@ fun EnhancedDriverScreen(
         // 终端对话框
         AnimatedVisibility(
             visible = showTerminalDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             TerminalDialog(
                 logs = terminalLogs,

--- a/app/src/main/java/com/gamecamp/ui/screens/GameAssistantScreen.kt
+++ b/app/src/main/java/com/gamecamp/ui/screens/GameAssistantScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.animation.*
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.*
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -74,8 +74,8 @@ fun GameAssistantScreen(
         // 辅助功能设置对话框
         AnimatedVisibility(
             visible = showAssistantDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             AssistantSettingsDialog(
                 currentSettings = assistantSettings,
@@ -92,8 +92,8 @@ fun GameAssistantScreen(
         // 终端对话框
         AnimatedVisibility(
             visible = showTerminalDialog,
-            enter = fadeIn(animationSpec = tween(200)) + scaleIn(initialScale = 0.9f),
-            exit = fadeOut(animationSpec = tween(200)) + scaleOut(targetScale = 0.9f)
+            enter = fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleIn(animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow), initialScale = 0.8f),
+            exit = fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) + scaleOut(animationSpec = spring(stiffness = Spring.StiffnessMediumLow), targetScale = 0.8f)
         ) {
             TerminalDialog(
                 logs = terminalLogs,


### PR DESCRIPTION
This commit enhances the UI animations based on your feedback to make them more 'lively' and 'fluid'. - Implements a staggered entry animation for the cards on the Dashboard screen, creating a cascading effect. - Replaces `tween`-based animations with `spring` physics for dialogs and screen entry animations. This gives them a more natural, bouncy feel. - These changes apply to `DashboardScreen`, `DriverScreen`, `EnhancedDriverScreen`, 和 `GameAssistantScreen`.